### PR TITLE
fix(email): unificar direcciones de soporte a .com y documentar Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,11 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
 FIREBASE_PROJECT_ID=
 FIREBASE_CLIENT_EMAIL=
 FIREBASE_PRIVATE_KEY=
+
+# Resend — notificaciones transaccionales (services/email-service.ts)
+# Sin RESEND_API_KEY las notificaciones por correo quedan desactivadas.
+# El remitente vive en el subdominio notificaciones.* para aislar la
+# reputación de envío del correo corporativo del dominio raíz.
+RESEND_API_KEY=
+EMAIL_FROM=BuscoCredito <notificaciones@notificaciones.buscocredito.com>
+NEXT_PUBLIC_APP_URL=https://www.buscocredito.com

--- a/app/admin_dashboard/page.tsx
+++ b/app/admin_dashboard/page.tsx
@@ -494,7 +494,7 @@ export default function AdminDashboard() {
                         <p className="text-sm text-gray-600 mb-3">
                           ¿Tienes problemas con la plataforma? Nuestro equipo está disponible para ayudarte.
                         </p>
-                        <p className="text-xs font-medium text-gray-500">soporte@buscocredito.mx</p>
+                        <p className="text-xs font-medium text-gray-500">soporte@buscocredito.com</p>
                       </div>
                     </div>
                   </div>

--- a/app/lender/page.tsx
+++ b/app/lender/page.tsx
@@ -247,7 +247,7 @@ function LenderPageContent() {
                       <p className="text-sm text-gray-600 mb-3">
                         ¿Tienes problemas con la plataforma? Nuestro equipo está disponible para ayudarte.
                       </p>
-                      <p className="text-xs font-medium text-gray-500">soporte@buscocredito.mx</p>
+                      <p className="text-xs font-medium text-gray-500">soporte@buscocredito.com</p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Qué cambia

**`soporte@buscocredito.mx` → `soporte@buscocredito.com`** en los dashboards de admin (`app/admin_dashboard/page.tsx:497`) y lender (`app/lender/page.tsx:250`).

Eran las dos únicas referencias `.mx` del código. El resto de la app —footer, términos, política de privacidad, transparencia, centro de ayuda— usa `.com`, igual que los documentos legales. Los alias del buzón están configurados en `buscocredito.com`, así que las direcciones `.mx` no resolvían a ningún lado.

Direcciones publicadas tras el cambio, todas con alias activo:

| Dirección | Usos |
|---|---|
| `privacidad@buscocredito.com` | 8 |
| `contacto@buscocredito.com` | 8 |
| `legal@buscocredito.com` | 7 |
| `soporte@buscocredito.com` | 5 |
| `transparencia@buscocredito.com` | 4 |

**`.env.example`** documenta las tres variables de Resend. No estaban declaradas en ningún lado, y sin `RESEND_API_KEY` el servicio sale temprano (`services/email-service.ts:615`) — las notificaciones de `nueva_propuesta`, `loan_accepted` y `loan_assigned_other` nunca se enviaron. Ya quedaron configuradas en Vercel.

El remitente vive en el subdominio `notificaciones.buscocredito.com` para que la reputación de envío transaccional no arrastre la del correo corporativo del dominio raíz.

## Verificación

- `npm run type-check` — limpio
- `npx eslint` sobre los archivos tocados — 0 errores (los 24 errores del lint completo son previos, en `useSuperAdminDashboard.ts` y `dashboard-service.ts`)
- Correo de prueba vía Resend entregado a Recibidos, no spam, con DMARC en `p=quarantine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)