### PR TITLE
test(auth): cubrir las tres rutas que deciden roles y alta de empresas

### DIFF
--- a/app/api/auth/setup-user-claims/__tests__/route.test.ts
+++ b/app/api/auth/setup-user-claims/__tests__/route.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+const mockVerifyIdToken = vi.fn();
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: () => ({
+    verifyIdToken: (...args: any[]) => mockVerifyIdToken(...args),
+  }),
+}));
+
+vi.mock("@/db/FirebaseAdmin", () => ({
+  initAdmin: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockUserDocGet = vi.fn();
+const mockUserDocUpdate = vi.fn().mockResolvedValue(undefined);
+const mockDoc = vi.fn().mockReturnValue({
+  get: mockUserDocGet,
+  update: mockUserDocUpdate,
+});
+const mockCollection = vi.fn().mockReturnValue({ doc: mockDoc });
+
+vi.mock("@/app/firebase-admin", () => ({
+  adminFirestore: {
+    collection: (...args: any[]) => mockCollection(...args),
+  },
+}));
+
+const mockOnUserCreated = vi.fn();
+vi.mock("@/db/AuthManager", () => ({
+  onUserCreated: (...args: any[]) => mockOnUserCreated(...args),
+}));
+
+function createRequest(
+  body: any,
+  opts: { cookie?: string; bearer?: string } = {}
+): NextRequest {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (opts.cookie) headers["cookie"] = `auth-token=${opts.cookie}`;
+  if (opts.bearer) headers["Authorization"] = `Bearer ${opts.bearer}`;
+
+  return new NextRequest("http://localhost:3000/api/auth/setup-user-claims", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+const validUserData = { name: "Roberto", email: "r@test.com" };
+
+describe("POST /api/auth/setup-user-claims — asignación de rol", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnUserCreated.mockResolvedValue({ success: true });
+  });
+
+  describe("autenticación", () => {
+    it("rechaza petición sin cookie ni Bearer", async () => {
+      const res = await POST(
+        createRequest({ userId: "user-1", userData: validUserData })
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("rechaza petición con token inválido", async () => {
+      mockVerifyIdToken.mockRejectedValue(new Error("token expirado"));
+
+      const res = await POST(
+        createRequest(
+          { userId: "user-1", userData: validUserData },
+          { cookie: "token-basura" }
+        )
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("acepta autenticación por Bearer cuando no hay cookie", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+      mockUserDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ type: "borrower" }),
+      });
+
+      const res = await POST(
+        createRequest(
+          { userId: "user-1", userData: validUserData },
+          { bearer: "token-bueno" }
+        )
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("autorización", () => {
+    it("impide configurar los claims de OTRO usuario", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "atacante-1" });
+
+      const res = await POST(
+        createRequest(
+          { userId: "victima-1", userData: validUserData },
+          { cookie: "token-bueno" }
+        )
+      );
+
+      expect(res.status).toBe(403);
+      // El guard debe cortar ANTES de tocar Firestore o asignar claims
+      expect(mockOnUserCreated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("el tipo de usuario viene de Firestore, nunca del cliente", () => {
+    it("ignora un type inyectado en el body y usa el de Firestore", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+      mockUserDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ type: "borrower" }),
+      });
+
+      const res = await POST(
+        createRequest(
+          {
+            userId: "user-1",
+            // El cliente intenta escalar privilegios
+            userData: { ...validUserData, type: "superAdmin" },
+          },
+          { cookie: "token-bueno" }
+        )
+      );
+
+      expect(res.status).toBe(200);
+
+      const [, payload] = mockOnUserCreated.mock.calls[0];
+      expect(payload.type).toBe("borrower");
+      expect(payload.type).not.toBe("superAdmin");
+
+      const body = await res.json();
+      expect(body.data.userType).toBe("borrower");
+    });
+  });
+
+  describe("estado del usuario en Firestore", () => {
+    it("responde 404 si el usuario no existe en cuentas", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+      mockUserDocGet.mockResolvedValue({ exists: false });
+
+      const res = await POST(
+        createRequest(
+          { userId: "user-1", userData: validUserData },
+          { cookie: "token-bueno" }
+        )
+      );
+
+      expect(res.status).toBe(404);
+      expect(mockOnUserCreated).not.toHaveBeenCalled();
+    });
+
+    it("responde 400 si el documento no tiene type", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+      mockUserDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ name: "Roberto" }),
+      });
+
+      const res = await POST(
+        createRequest(
+          { userId: "user-1", userData: validUserData },
+          { cookie: "token-bueno" }
+        )
+      );
+
+      expect(res.status).toBe(400);
+      expect(mockOnUserCreated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("validación de campos", () => {
+    it("responde 400 si falta userData", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+
+      const res = await POST(
+        createRequest({ userId: "user-1" }, { cookie: "token-bueno" })
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("responde 400 si userData no trae email", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+
+      const res = await POST(
+        createRequest(
+          { userId: "user-1", userData: { name: "Roberto" } },
+          { cookie: "token-bueno" }
+        )
+      );
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("camino feliz", () => {
+    it("asigna claims y actualiza el timestamp", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+      mockUserDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ type: "companyAdmin" }),
+      });
+
+      const res = await POST(
+        createRequest(
+          { userId: "user-1", userData: validUserData },
+          { cookie: "token-bueno" }
+        )
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.data.userType).toBe("companyAdmin");
+      expect(mockOnUserCreated).toHaveBeenCalledWith(
+        "user-1",
+        expect.objectContaining({ type: "companyAdmin" })
+      );
+      expect(mockUserDocUpdate).toHaveBeenCalled();
+    });
+
+    it("responde 500 si onUserCreated falla", async () => {
+      mockVerifyIdToken.mockResolvedValue({ uid: "user-1" });
+      mockUserDocGet.mockResolvedValue({
+        exists: true,
+        data: () => ({ type: "borrower" }),
+      });
+      mockOnUserCreated.mockResolvedValue({
+        success: false,
+        error: "Firebase caído",
+      });
+
+      const res = await POST(
+        createRequest(
+          { userId: "user-1", userData: validUserData },
+          { cookie: "token-bueno" }
+        )
+      );
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/app/api/auth/use-bank-token/__tests__/route.test.ts
+++ b/app/api/auth/use-bank-token/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+vi.mock("@/db/FirebaseAdmin", () => ({
+  initAdmin: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGet = vi.fn();
+const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+const mockWhereUsed = vi.fn().mockReturnValue({ limit: mockLimit });
+const mockWhereToken = vi.fn().mockReturnValue({ where: mockWhereUsed });
+
+const mockUpdate = vi.fn().mockResolvedValue(undefined);
+const mockDoc = vi.fn().mockReturnValue({ update: mockUpdate });
+
+const mockCollection = vi.fn().mockReturnValue({
+  where: mockWhereToken,
+  doc: mockDoc,
+});
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: (...args: any[]) => mockCollection(...args),
+  }),
+}));
+
+function createRequest(body: any): NextRequest {
+  return new NextRequest("http://localhost:3000/api/auth/use-bank-token", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function tokenEncontrado() {
+  mockGet.mockResolvedValue({
+    empty: false,
+    docs: [{ id: "token-doc-1", data: () => ({}) }],
+  });
+}
+
+describe("POST /api/auth/use-bank-token — quemar token de alta de empresa", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("validación de entrada", () => {
+    it("responde 400 si falta el token", async () => {
+      const res = await POST(createRequest({ usedBy: "user-1" }));
+
+      expect(res.status).toBe(400);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("responde 400 si falta usedBy", async () => {
+      const res = await POST(createRequest({ token: "token-bueno" }));
+
+      expect(res.status).toBe(400);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("token inválido o ya usado", () => {
+    it("responde 400 y no escribe nada", async () => {
+      mockGet.mockResolvedValue({ empty: true, docs: [] });
+
+      const res = await POST(
+        createRequest({ token: "token-quemado", usedBy: "user-1" })
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("solo busca entre tokens sin usar", async () => {
+      mockGet.mockResolvedValue({ empty: true, docs: [] });
+
+      await POST(createRequest({ token: "token-x", usedBy: "user-1" }));
+
+      expect(mockWhereToken).toHaveBeenCalledWith("token", "==", "token-x");
+      expect(mockWhereUsed).toHaveBeenCalledWith("used", "==", false);
+    });
+  });
+
+  describe("camino feliz", () => {
+    it("marca el token como usado y registra quién lo usó", async () => {
+      tokenEncontrado();
+
+      const res = await POST(
+        createRequest({
+          token: "token-bueno",
+          usedBy: "user-1",
+          companyName: "Banco Azteca",
+        })
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+
+      expect(mockDoc).toHaveBeenCalledWith("token-doc-1");
+      const [payload] = mockUpdate.mock.calls[0];
+      expect(payload.used).toBe(true);
+      expect(payload.usedBy).toBe("user-1");
+      expect(payload.usedByCompany).toBe("Banco Azteca");
+      expect(payload.usedAt).toBeInstanceOf(Date);
+    });
+
+    it("acepta que no venga companyName y lo guarda como null", async () => {
+      tokenEncontrado();
+
+      const res = await POST(
+        createRequest({ token: "token-bueno", usedBy: "user-1" })
+      );
+
+      expect(res.status).toBe(200);
+      const [payload] = mockUpdate.mock.calls[0];
+      expect(payload.usedByCompany).toBeNull();
+    });
+  });
+
+  it("responde 500 si la escritura falla", async () => {
+    tokenEncontrado();
+    mockUpdate.mockRejectedValueOnce(new Error("Firestore caído"));
+
+    const res = await POST(
+      createRequest({ token: "token-bueno", usedBy: "user-1" })
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});

--- a/app/api/auth/validate-bank-token/__tests__/route.test.ts
+++ b/app/api/auth/validate-bank-token/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+vi.mock("@/db/FirebaseAdmin", () => ({
+  initAdmin: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGet = vi.fn();
+const mockLimit = vi.fn().mockReturnValue({ get: mockGet });
+const mockWhereUsed = vi.fn().mockReturnValue({ limit: mockLimit });
+const mockWhereToken = vi.fn().mockReturnValue({ where: mockWhereUsed });
+const mockCollection = vi.fn().mockReturnValue({ where: mockWhereToken });
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: () => ({
+    collection: (...args: any[]) => mockCollection(...args),
+  }),
+}));
+
+function createRequest(body: any): NextRequest {
+  return new NextRequest("http://localhost:3000/api/auth/validate-bank-token", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/auth/validate-bank-token — validar token de alta de empresa", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("responde 400 si no se envía token", async () => {
+    const res = await POST(createRequest({}));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.valid).toBe(false);
+    // No debe llegar a consultar Firestore
+    expect(mockCollection).not.toHaveBeenCalled();
+  });
+
+  it("responde 400 si el token es cadena vacía", async () => {
+    const res = await POST(createRequest({ token: "" }));
+
+    expect(res.status).toBe(400);
+    expect(mockCollection).not.toHaveBeenCalled();
+  });
+
+  it("rechaza un token inexistente sin revelar por qué", async () => {
+    mockGet.mockResolvedValue({ empty: true, docs: [] });
+
+    const res = await POST(createRequest({ token: "token-inventado" }));
+    const body = await res.json();
+
+    expect(body.valid).toBe(false);
+    expect(body.tokenId).toBeUndefined();
+  });
+
+  it("solo considera tokens sin usar", async () => {
+    mockGet.mockResolvedValue({ empty: true, docs: [] });
+
+    await POST(createRequest({ token: "token-quemado" }));
+
+    expect(mockCollection).toHaveBeenCalledWith("bank_signup_tokens");
+    expect(mockWhereToken).toHaveBeenCalledWith("token", "==", "token-quemado");
+    expect(mockWhereUsed).toHaveBeenCalledWith("used", "==", false);
+  });
+
+  it("acepta un token válido y devuelve su id", async () => {
+    mockGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          id: "token-doc-1",
+          data: () => ({ description: "Alta Banco Azteca" }),
+        },
+      ],
+    });
+
+    const res = await POST(createRequest({ token: "token-bueno" }));
+    const body = await res.json();
+
+    expect(body.valid).toBe(true);
+    expect(body.tokenId).toBe("token-doc-1");
+    expect(body.description).toBe("Alta Banco Azteca");
+  });
+
+  it("responde 500 si Firestore falla", async () => {
+    mockGet.mockRejectedValue(new Error("Firestore caído"));
+
+    const res = await POST(createRequest({ token: "token-bueno" }));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.valid).toBe(false);
+  });
+});


### PR DESCRIPTION
Ninguna de estas tres rutas tenía tests, y son las que controlan quién puede registrar una empresa en el marketplace y con qué rol termina. **No se modificó código de producción** — solo se agregaron tests.

| Ruta | Tests | Qué protege |
|---|---|---|
| `auth/setup-user-claims` | 11 | Asignación de rol |
| `auth/use-bank-token` | 7 | Quemar el token de alta |
| `auth/validate-bank-token` | 6 | Validar el token de alta |

## El test que más importa

`setup-user-claims` lee el tipo de usuario del documento de Firestore, **nunca del body** (`route.ts:60-74`). Hay un test que ataca exactamente eso:

```ts
userData: { ...validUserData, type: "superAdmin" }   // el cliente intenta escalar
// Firestore dice "borrower"
expect(payload.type).toBe("borrower");
expect(payload.type).not.toBe("superAdmin");
```

Si alguien "simplifica" esa línea a `const safeUserData = userData`, la suite se pone roja.

## Verificación por mutación

Los tests escritos después del código pasan de inmediato, lo cual no prueba nada — pueden estar verificando lo equivocado. Así que se quitó temporalmente cada guard de producción y se confirmó que la suite falla:

| Guard removido | Tests que fallan |
|---|---|
| `setup-user-claims` — autenticación (401) | 2 |
| `setup-user-claims` — identidad `userId !== callerUid` (403) | 1 |
| `setup-user-claims` — tipo desde Firestore | 2 |
| `validate-bank-token` — filtro `used == false` | 2 |
| `validate-bank-token` — token requerido | 2 |
| `use-bank-token` — filtro `used == false` | 4 |
| `use-bank-token` — campos requeridos | 2 |

Siete de siete cubiertos. Los tres `route.ts` quedaron byte a byte idénticos al original (verificado con `diff`).

## Dos hallazgos que NO se arreglan aquí

Salieron al leer el código. Se reportan, no se tocan — este PR es solo tests.

**1. `use-bank-token` tiene una condición de carrera.** La consulta y el `update` no van en una transacción (`route.ts:20-41`). Dos peticiones simultáneas con el mismo token pueden pasar ambas el filtro `used == false` antes de que cualquiera escriba, y las dos tendrían éxito — un token de alta serviría para registrar dos empresas. Se arregla con `db.runTransaction()`.

**2. Ambas rutas de token son públicas y sin límite de tasa.** No llevan autenticación, cosa que el flujo de alta necesita: todavía no hay cuenta. Pero `validate-bank-token` funciona como oráculo — responde si un token existe o no, sin costo y sin tope de intentos.

## Verificación

- `npm run test` — 124/124, 11 archivos (antes: 100/100, 8 archivos)
- `npm run type-check` — limpio
- `npx eslint` sobre los tres archivos nuevos — 0 problemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)